### PR TITLE
Fix new .torrent filename when folder name contains dots

### DIFF
--- a/lib/transplant.py
+++ b/lib/transplant.py
@@ -401,5 +401,5 @@ class Transplanter:
         dtor = files.dtors[0].as_dict(u_strip=self.strip_tor)
         if comment:
             dtor['comment'] = comment
-        file_path = (self.dtor_save_dir / self.tor_info.folder_name).with_suffix('.torrent')
+        file_path = self.dtor_save_dir / (self.tor_info.folder_name + '.torrent')
         file_path.write_bytes(bencode(dtor))


### PR DESCRIPTION
Fix cases such as 'Compilation Vol. 1', when '. 1' was considered as a suffix and was replaced with '.torrent'.